### PR TITLE
Feature/cdk paged fetching v2

### DIFF
--- a/projects/ng-table-virtual-scroll/package.json
+++ b/projects/ng-table-virtual-scroll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cactusoft-ca/ng-table-virtual-scroll",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Virtual scroll for for Angular Material Table",
   "homepage": "https://github.com/diprokon/ng-table-virtual-scroll",
   "repository": {

--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -14,8 +14,12 @@ import {
   Subscription,
 } from 'rxjs';
 import { GenerateBaseOptions } from 'rxjs/internal/observable/generate';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { concatMap, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
 
+/**
+ * @page The page of the request to get. The table data source uses a zero based index implying that the first page is 0
+ * @size The number of items to fetch
+ */
 export interface TVSPageRequest {
   page: number;
   size: number;
@@ -78,19 +82,21 @@ export class CdkTableVirtualScrollDataSource<T> extends DataSource<T> implements
           let cachedPages = new Set<number>();
           let maxPage = Number.MAX_VALUE;
           return collectionViewer.viewChange.pipe(
-            switchMap(listRange => {
-              if (listRange.start === 0 && listRange.end === Number.MAX_VALUE) return of();
-              const startPage = Math.floor(listRange.start / pageSettings.pageSize);
-              const endPage = Math.ceil(listRange.end / pageSettings.pageSize) - 1;
-
+            filter(listRange => !(listRange.start === 0 && listRange.end === Number.MAX_VALUE)),
+            map(listRange => ({
+              startPage: Math.floor(listRange.start / pageSettings.pageSize),
+              endPage: Math.ceil(listRange.end / pageSettings.pageSize) - 1,
+            })),
+            distinctUntilChanged((x, y) => x.startPage === y.startPage && x.endPage === y.endPage),
+            switchMap(paging => {
               const pages$ = generate(<GenerateBaseOptions<number>>{
-                initialState: startPage,
-                condition: x => x <= endPage && x <= maxPage,
+                initialState: paging.startPage,
+                condition: x => x <= paging.endPage && x <= maxPage,
                 iterate: x => x + 1,
               });
 
               return pages$.pipe(
-                switchMap(page => {
+                concatMap(page => {
                   if (cachedPages.has(page)) {
                     return of(cache);
                   } else {
@@ -117,7 +123,7 @@ export class CdkTableVirtualScrollDataSource<T> extends DataSource<T> implements
                           cache = cache.slice();
 
                           // Replace the cache content
-                          cache.splice(startPage * pageSettings.pageSize, tvsPage.content.length, ...tvsPage.content);
+                          cache.splice(page * pageSettings.pageSize, tvsPage.content.length, ...tvsPage.content);
 
                           // Add the page to the cache
                           cachedPages.add(page);

--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -14,7 +14,7 @@ import {
   Subscription,
 } from 'rxjs';
 import { GenerateBaseOptions } from 'rxjs/internal/observable/generate';
-import { concatMap, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 
 /**
  * @page The page of the request to get. The table data source uses a zero based index implying that the first page is 0

--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -96,7 +96,7 @@ export class CdkTableVirtualScrollDataSource<T> extends DataSource<T> implements
               });
 
               return pages$.pipe(
-                concatMap(page => {
+                mergeMap(page => {
                   if (cachedPages.has(page)) {
                     return of(cache);
                   } else {


### PR DESCRIPTION
Quelques petites améliorations à la ng-table pour pas faire des calls pour rien et afin de changer le switchMap par un concatMap pour s'assurer que quand on a créer les pages et qu'on se met à hit le endpoint, qu'on finisse le call avant de passer à un autre

Donc présentement, on switchMap le viewChange, donc s'il n'a même pas le temps de générer ses pages avant de passer à une autre, on va cancel la request mais si on s'arrête assez longtemps, on commit et on fait le call

Ça me fait penser que peut-être qu'on pourrait mettre un debounceTime pour s'assurer que le user a vraiment arrêter de scroll avant de load la page mais je crois que ça l'ajouterais du délais pour pas grand chose